### PR TITLE
Improve snapcraft.yaml

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,4 +32,8 @@ gulp.task('copy', ['sass'], function () {
     gulp.src(srcs).pipe(gulp.dest('./meta_maas/html/libs'));
 });
 
+gulp.task('snap-install', ['default'], function () {
+    gulp.src('./meta_maas/html/**').pipe(gulp.dest(process.env.SNAPCRAFT_PART_INSTALL));
+});
+
 gulp.task('default', ['copy']);

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,16 +17,12 @@ parts:
     plugin: python
     source: .
     requirements: requirements.txt
-  meta-html-build:
+  meta-html:
     plugin: gulp
     source: .
     gulp-tasks:
       - default
-  meta-html-install:
-    plugin: dump
-    source: parts/meta-html-build/build/meta_maas/html
-    after:
-      - meta-html-build
+      - snap-install
     organize:
       assets: lib/python3.5/site-packages/meta_maas/html/assets
       libs: lib/python3.5/site-packages/meta_maas/html/libs


### PR DESCRIPTION
Paths of the form `parts/.../.../` shouldn't be used as those
are subject to change depending on the environment they are
run on.

Signed-off-by: Sergio Schvezov <sergio.schvezov@ubuntu.com>