### PR TITLE
Design update

### DIFF
--- a/meta_maas/html/index.html
+++ b/meta_maas/html/index.html
@@ -17,6 +17,25 @@
     <script type="text/javascript" src="libs/angular-chart.min.js"></script>
     <script type="text/javascript" src="libs/meta_maas.js"></script>
     <script type="text/javascript" src="data.js"></script>
+    <style media="screen">
+      a {
+        border-bottom: 0;
+        color: #007aa6;
+      }
+
+      a:hover {
+        color: #007aa6;
+        text-decoration: underline;
+      }
+
+      h1 a {
+        color: #333333;
+      }
+
+      h1 a:hover {
+        color: #333333;
+      }
+    </style>
 </head>
 <body ng-app="meta-maas">
     <div class="wrapper--flex">
@@ -93,13 +112,21 @@
                     <div class="wrapper--inner">
                         <div class="six-col" data-ng-repeat="(name, info) in regions" ng-class-even="'last-col'">
                             <div class="action-card">
-                                <h1 class="action-card__title"><a href="{{info.url}}" target="_blank">{{name}}</a></h1>
+                                <h1 class="action-card__title u-border--bottom u-border--dotted u-margin--top-none u-padding--bottom-small">
+                                    <a href="{{info.url}}" target="_blank">{{name}}</a>
+                                </h1>
                                 <h3 data-ng-if="!info.statuses.data.length" class="u-text--center">0 machines</h3>
                                 <div data-ng-if="info.statuses.data.length">
                                     <canvas class="chart chart-doughnut"
-                                        chart-data="info.statuses.data" chart-labels="info.statuses.labels"
-                                        chart-options="options">
+                                        chart-data="info.statuses.data"
+                                        chart-labels="info.statuses.labels"
+                                        chart-colors="colors"
+                                        chart-options="options"
+                                        chart-dataset-override="datasetOverride">
                                     </canvas>
+                                </div>
+                                <div class="u-border--top u-border--dotted u-width--full u-text--right u-padding--top-small">
+                                    <p>{{info.machine_count}} nodes in {{name}} region. <a href="{{info.url}}" target="_blank">See details.</a></p>
                                 </div>
                             </div>
                         </div>

--- a/meta_maas/html/libs/meta_maas.js
+++ b/meta_maas/html/libs/meta_maas.js
@@ -1,18 +1,38 @@
 // Copyright 2016 Canonical Ltd.  This software is licensed under the
 // GNU Affero General Public License version 3 (see the file LICENSE).
 
-angular.module('meta-maas', ['chart.js'])
-    .controller('IndexCtrl', function($scope, metaData) {
-        $scope.regions = metaData.regions;
-        $scope.options = {
-            legend: {
-                display: true,
-                position: 'right',
-                labels: {
-                    boxWidth: 30,
-                    fontSize: 14,
-                    fontFamily: 'Ubuntu',
-                }
-            }
-        };
-    });
+(function () {
+  'use strict';
+
+  var app = angular.module('meta-maas', ['chart.js'])
+
+  app.controller('IndexCtrl', function($scope, metaData) {
+      $scope.regions = metaData.regions;
+      $scope.options = {
+          legend: {
+              display: true,
+              position: 'right',
+              labels: {
+                  fontColor: '#333',
+                  fontStyle: '300',
+                  boxWidth: 16,
+                  fontSize: 16,
+                  fontFamily: 'Ubuntu, Arial, "libra sans", sans-serif',
+                  padding: 20
+              }
+          },
+          cutoutPercentage: 95,
+          tooltips: {
+              backgroundColor: '#333',
+              bodyFontSize: 16,
+              bodyFontFamily: 'Ubuntu, Arial, "libra sans", sans-serif',
+              bodyFontStyle: '300',
+              yPadding: 10,
+              titleMarginBottom: 15
+          }
+      }
+      $scope.colors = ['#ffb95a', '#ff8936', '#8db255', '#749f8d', '#48929b', '#a87ca0', '#dc3023', '#888888'];
+      $scope.datasetOverride = [{ cutoutPercentage: 90 }]
+  });
+
+})();

--- a/meta_maas/report.py
+++ b/meta_maas/report.py
@@ -26,8 +26,10 @@ def render_data(regions):
     data = {}
     for region in regions:
         statuses = defaultdict(int)
+        count = 0
         for machine in region.origin.Machines.read():
             statuses[machine.status_name] += 1
+            count += 1
         labels = sorted(statuses.keys())
         data[region.name] = {
             'url': region.url,
@@ -37,7 +39,8 @@ def render_data(regions):
                     for label in labels
                 ],
                 'labels': labels,
-            }
+            },
+            'machine_count': count,
         }
     return SERVICE_TEMPLATE % json.dumps(data)
 

--- a/meta_maas/tests/test_report.py
+++ b/meta_maas/tests/test_report.py
@@ -38,11 +38,13 @@ def test_render_data_outputs_angular_service():
     region_one.url = "http://region_one"
     region_one.origin.Machines.read.return_value = [
         machine_one, machine_two, machine_three, machine_four]
+    region_one.machine_count = 4
     region_two = MagicMock()
     region_two.name = "region_two"
     region_two.url = "http://region_two"
     region_two.origin.Machines.read.return_value = [
         machine_one, machine_two, machine_three, machine_four]
+    region_two.machine_count = 4
     output = {
         region_one.name: {
             "url": region_one.url,
@@ -50,13 +52,15 @@ def test_render_data_outputs_angular_service():
                 "data": [1, 2, 1],
                 "labels": ["Allocated", "New", "Ready"],
             }
+            "machine_count": region_one.machine_count,
         },
         region_two.name: {
             "url": region_two.url,
             "statuses": {
                 "data": [1, 2, 1],
                 "labels": ["Allocated", "New", "Ready"],
-            }
+            },
+            "machine_count": region_two.machine_count,
         },
     }
     output_js = SERVICE_TEMPLATE % json.dumps(output)

--- a/meta_maas/tests/test_report.py
+++ b/meta_maas/tests/test_report.py
@@ -51,7 +51,7 @@ def test_render_data_outputs_angular_service():
             "statuses": {
                 "data": [1, 2, 1],
                 "labels": ["Allocated", "New", "Ready"],
-            }
+            },
             "machine_count": region_one.count,
         },
         region_two.name: {

--- a/meta_maas/tests/test_report.py
+++ b/meta_maas/tests/test_report.py
@@ -38,13 +38,13 @@ def test_render_data_outputs_angular_service():
     region_one.url = "http://region_one"
     region_one.origin.Machines.read.return_value = [
         machine_one, machine_two, machine_three, machine_four]
-    region_one.machine_count = 4
+    region_one.count = 4
     region_two = MagicMock()
     region_two.name = "region_two"
     region_two.url = "http://region_two"
     region_two.origin.Machines.read.return_value = [
         machine_one, machine_two, machine_three, machine_four]
-    region_two.machine_count = 4
+    region_two.count = 4
     output = {
         region_one.name: {
             "url": region_one.url,
@@ -52,7 +52,7 @@ def test_render_data_outputs_angular_service():
                 "data": [1, 2, 1],
                 "labels": ["Allocated", "New", "Ready"],
             }
-            "machine_count": region_one.machine_count,
+            "machine_count": region_one.count,
         },
         region_two.name: {
             "url": region_two.url,
@@ -60,7 +60,7 @@ def test_render_data_outputs_angular_service():
                 "data": [1, 2, 1],
                 "labels": ["Allocated", "New", "Ready"],
             },
-            "machine_count": region_two.machine_count,
+            "machine_count": region_two.count,
         },
     }
     output_js = SERVICE_TEMPLATE % json.dumps(output)


### PR DESCRIPTION
#Done
Updated the colour link style to replicate what is live on the MAAS app. The piechart is now thinner and follows the designs provided. Also assigned new colours to the pie chart, this only works for the first amount of labels further work is needed to limit the labels.

We now represent how many machines are on the region in the footer of each card with a link to the region as well.

#QA

- Pull down the branch 
- Make sure you're details connect to the region and run ```.tox/py35/bin/meta-maas -r output``` 
- View the ```index.html``` file in the output folder